### PR TITLE
Use Std.isOfType instead of Std.is

### DIFF
--- a/src/hex/log/filter/AbstractFilterable.hx
+++ b/src/hex/log/filter/AbstractFilterable.hx
@@ -25,7 +25,7 @@ class AbstractFilterable implements IFilterable
 		{
 			this.filter = filter;
 		}
-		else if (Std.is(this.filter, CompositeFilter))
+		else if (Std.isOfType(this.filter, CompositeFilter))
 		{
 			this.filter = (cast this.filter:CompositeFilter).addFilter(filter);
 		}
@@ -45,7 +45,7 @@ class AbstractFilterable implements IFilterable
 		{
 			this.filter = null;
 		}
-		else if (Std.is(this.filter, CompositeFilter))
+		else if (Std.isOfType(this.filter, CompositeFilter))
 		{
 			var composite:CompositeFilter = cast this.filter;
 			composite = composite.removeFilter(filter);

--- a/src/hex/log/filter/CompositeFilter.hx
+++ b/src/hex/log/filter/CompositeFilter.hx
@@ -26,7 +26,7 @@ class CompositeFilter implements IFilter
 		{
 			return this;
 		}
-		if (Std.is(filter, CompositeFilter))
+		if (Std.isOfType(filter, CompositeFilter))
 		{
 			var composite:CompositeFilter = cast filter;
 			return new CompositeFilter(filters.copy().concat(composite.filters.copy()));
@@ -44,7 +44,7 @@ class CompositeFilter implements IFilter
 		}
 		
 		var newFilters = filters.copy();
-		if (Std.is(filter, CompositeFilter))
+		if (Std.isOfType(filter, CompositeFilter))
 		{
 			var composite:CompositeFilter = cast filter;
 			for (f in composite.filters)

--- a/src/hex/log/internal/AbstractLogger.hx
+++ b/src/hex/log/internal/AbstractLogger.hx
@@ -85,7 +85,7 @@ class AbstractLogger implements IExtendedLogger
 	{
 		if (isEnabled(level, message, params, posInfos))
 		{
-			if(Std.is(message, String) || message == null)
+			if(Std.isOfType(message, String) || message == null)
 			{
 				logEnabledMessage(level, messageFactory.newMessage(message, params), posInfos);
 			}


### PR DESCRIPTION
`Std.is` is now deprecated and causes warnings with latest Haxe 4.2:

```
~/.haxelib/hexlog/1,0,0-alpha,7/src/hex/log/filter/AbstractFilterable.hx:28: characters 12-48 : Warning : Std.is is deprecated. Use Std.isOfType instead.
~/.haxelib/hexlog/1,0,0-alpha,7/src/hex/log/filter/AbstractFilterable.hx:48: characters 12-48 : Warning : Std.is is deprecated. Use Std.isOfType instead.
~/.haxelib/hexlog/1,0,0-alpha,7/src/hex/log/internal/AbstractLogger.hx:88: characters 7-30 : Warning : Std.is is deprecated. Use Std.isOfType instead.
~/.haxelib/hexlog/1,0,0-alpha,7/src/hex/log/filter/CompositeFilter.hx:29: characters 7-38 : Warning : Std.is is deprecated. Use Std.isOfType instead.
~/.haxelib/hexlog/1,0,0-alpha,7/src/hex/log/filter/CompositeFilter.hx:47: characters 7-38 : Warning : Std.is is deprecated. Use Std.isOfType instead.
```

This simple PR silences the warnings.